### PR TITLE
Fix 500 error when uploading form templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 
 .env
+.idea


### PR DESCRIPTION
## What changes did you make?

Modified the handleOkPress function in FormList.js to parse the uploaded JSON and extract only the required fields (id, form_id, deployed_to, pdf_template_id) before sending to the /api/forms/update endpoint. Added logic to handle both formversion nested structure and flat root-level JSON formats.

## Why did you make these changes?

The form upload was failing with a 500 Internal Server Error because the entire form template JSON was being sent to the update endpoint, but the backend only expects specific deployment-related fields. This caused database query failures when the endpoint couldn't extract the required parameters from the nested JSON.

## What alternatives did you consider?

### Checklist

- [ ] **I have assigned at least one reviewer**
- [X] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
