### PR TITLE
3443 - Fix form rendering bug in kiln-v2 by adding support for `scripts` and `styles` fields in template-repository.

### DIFF
--- a/app/src/formRoutes.js
+++ b/app/src/formRoutes.js
@@ -12,6 +12,13 @@ const PETS_BASE_URL = process.env.PETS_BASE_URL;
 
 function convertToFormVersion(result) {
   return {
+    id: result.id,
+    title: result.title,
+    form_id: result.form_id,
+    version: result.version,
+    deployed_to: result.deployed_to || '',
+    last_modified: result.last_modified,
+    pdf_template_id: result.pdf_template_id || null,
     formversion: {
       id: result.id,
       name: result.title,

--- a/app/src/formRoutes.js
+++ b/app/src/formRoutes.js
@@ -10,12 +10,7 @@ const upload = multer();
 
 const PETS_BASE_URL = process.env.PETS_BASE_URL;
 
-/**
- * Transform database row to formversion API response format
- * @param {Object} result - Database row from form_templates table
- * @returns {Object} Transformed response in formversion format
- */
-function transformToFormversion(result) {
+function convertToFormVersion(result) {
   return {
     formversion: {
       id: result.id,
@@ -120,7 +115,7 @@ router.get('/forms/:id', async (req, res) => {
     const result = await db('form_templates').where({ id }).first();
 
     if (result) {
-      res.status(200).json(transformToFormversion(result));
+      res.status(200).json(convertToFormVersion(result));
     } else {
       res.status(404).send('Form template not found');
     }
@@ -149,7 +144,7 @@ router.get('/forms/form_id/:form_id', async (req, res) => {
       .first();
 
     if (result) {
-      res.status(200).json(transformToFormversion(result));
+      res.status(200).json(convertToFormVersion(result));
     } else {
       res.status(404).send('Form template not found');
     }
@@ -165,7 +160,7 @@ router.get('/forms-list', protectedRoute(), async (req, res) => {
     const results = await db('form_templates').select('*');
 
     if (results.length > 0) {
-      const transformedResults = results.map(result => transformToFormversion(result));
+      const transformedResults = results.map(result => convertToFormVersion(result));
       res.status(200).json(transformedResults);
     } else {
       res.status(404).send('No form templates found');

--- a/app/src/migrations/20251017184255_add_scripts_styles_to_form_templates.js
+++ b/app/src/migrations/20251017184255_add_scripts_styles_to_form_templates.js
@@ -1,0 +1,24 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  const exists = await knex.schema.hasTable("form_templates");
+  if (exists) {
+    return knex.schema.alterTable("form_templates", (table) => {
+      table.jsonb("scripts");
+      table.jsonb("styles");
+    });
+  }
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable("form_templates", (table) => {
+    table.dropColumn("scripts");
+    table.dropColumn("styles");
+  });
+};


### PR DESCRIPTION
## What changes did you make?

Added support for scripts and styles fields in template-repository.

1. Database Migration (20251017184255_add_scripts_styles_to_form_templates.js):
    - Added scripts (JSONB) column to form_templates table
    - Added styles (JSONB) column to form_templates table
 2. API Endpoints (formRoutes.js):
    - POST /forms: Extract and store scripts/styles from incoming requests
    - GET /forms/:id: Return scripts/styles in transformed response
    - GET /forms/form_id/:form_id: Return scripts/styles in transformed response
    - GET /forms-list: Return scripts/styles for all forms in list

## Why did you make these changes?

Forms uploaded to `template-repository` were missing their scripts and styles arrays when retrieved, causing kiln-v2 forms to render incorrectly. Kiln-v2 uses a configuration-driven architecture where form behavior (JavaScript) and styling (CSS) are stored in the JSON definition itself. Without these fields, custom form functionality and styling were lost.

## What alternatives did you consider?

Modify frontend to inject scripts/styles at runtime - Rejected because this would require changes across multiple services and wouldn't solve the data loss problem

### Checklist

- [X] **I have assigned at least one reviewer**
- [X] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
