### PR TITLE
Fix REST API behavior and add accessibility labels

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Dependencies - these are installed fresh during build
+node_modules
+app/src/node_modules
+app/client/node_modules
+
+# Build outputs - these are generated during build
+app/client/build
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Git
+.git
+.gitignore
+
+# IDE
+.vscode
+.idea
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Documentation
+README.md
+
+# CI/CD
+.github

--- a/app/client/src/pages/FormList.js
+++ b/app/client/src/pages/FormList.js
@@ -445,7 +445,7 @@ const FormList = () => {
                 </Button>
             </Header>
             <Modal isOpen={modalVisible} onOpenChange={setModalVisible}>
-                <Dialog isCloseable role="dialog">
+                <Dialog isCloseable role="dialog" aria-label="Upload Form Template">
                     <div className="dialog-container"
                          style={{
                              padding: "1rem",
@@ -465,6 +465,7 @@ const FormList = () => {
                                 ↻
                             </Button>
                             <TextField
+                                label="Template UUID"
                                 value={templateUuid}
                                 onChange={(val) => setTemplateUuid(val)}
                                 style={{
@@ -497,6 +498,7 @@ const FormList = () => {
                             </Button>
                         </div>
                         <TextArea
+                            label="Form Template JSON"
                             placeholder="Paste Form Template JSON here..."
                             value={inputText}
                             onChange={(value) => setInputText(value)}
@@ -514,7 +516,7 @@ const FormList = () => {
             </Modal>
             {selectedJson && (
                 <Modal isOpen={!!selectedJson} onOpenChange={() => setSelectedJson(null)}>  {/*Modal for Uploading JSON*/}
-                    <Dialog isCloseable>
+                    <Dialog isCloseable aria-label="JSON Preview">
                         <div style={{ height: "91vh", padding: "1vh" }}>
                             <h2>JSON Preview</h2>
                             <pre style={{ overflow: "auto", maxHeight: "75vh" }}>
@@ -538,7 +540,7 @@ const FormList = () => {
             ) : (
                 <><MaterialReactTable table={table} />
                     <Modal isOpen={isEditModalVisible} onOpenChange={setIsEditModalVisible} title="Change Deployment Status"> {/*Modal for Changing Deployement Status*/}
-                        <Dialog isCloseable>
+                        <Dialog isCloseable aria-label="Edit Deployment Status">
                             <div style={{ padding: "16px" }}>
                                 <h3>Edit Deployment Status</h3>
                                 <select

--- a/app/client/src/pages/FormList.js
+++ b/app/client/src/pages/FormList.js
@@ -118,8 +118,16 @@ const FormList = () => {
                 headers: { "Content-Type": "application/json", "Authorization": getAuthorizationHeaderValue() },
                 body: inputText,
             });
+
             if (!uploadResponse.ok) {
-                throw new Error(`Failed to upload template: ${uploadResponse.status} – ${uploadResponse.statusText}`);
+                const errorData = await uploadResponse.json().catch(() => ({}));
+                console.error('[Form Upload Error]', {
+                    status: uploadResponse.status,
+                    statusText: uploadResponse.statusText,
+                    errorData,
+                    payload: inputText.substring(0, 200) + '...',
+                });
+                throw new Error(errorData.message || `Upload failed: ${uploadResponse.status} ${uploadResponse.statusText}`);
             }
 
             const parsedJson = JSON.parse(inputText);
@@ -149,8 +157,18 @@ const FormList = () => {
                         pdf_template_id: null
                     }),
                 });
+
                 if (!updateResponse.ok) {
-                    throw new Error(`Failed to update template: ${updateResponse.status} – ${updateResponse.statusText}`);
+                    const errorData = await updateResponse.json().catch(() => ({}));
+                    console.error('[Form Update Error]', {
+                        status: updateResponse.status,
+                        statusText: updateResponse.statusText,
+                        errorData,
+                        formId,
+                        formUuid,
+                        deployedTo,
+                    });
+                    throw new Error(errorData.message || `Update failed: ${updateResponse.status} ${updateResponse.statusText}`);
                 }
             }
 
@@ -159,7 +177,10 @@ const FormList = () => {
             setErrorModal("");
             setModalVisible(false);
         } catch (err) {
-            console.error("Error uploading form:", err);
+            console.error('[Form Upload Handler Error]', {
+                error: err.message,
+                stack: err.stack,
+            });
             setErrorModal(err.message);
         }
     };

--- a/app/client/src/pages/PDFTemplates.js
+++ b/app/client/src/pages/PDFTemplates.js
@@ -253,7 +253,7 @@ const PdfTemplates = () => {
         <MaterialReactTable table={table} />
       )}
       <Modal isOpen={showUpload} onOpenChange={() => setShowUpload(false)}>
-        <Dialog isCloseable role="dialog">
+        <Dialog isCloseable role="dialog" aria-label="Upload PDF Template">
         <div
            style={{
               padding: "1rem",

--- a/app/src/controllers/formController.js
+++ b/app/src/controllers/formController.js
@@ -59,14 +59,7 @@ const getFormByFormId = async (req, res, next) => {
 const getAllForms = async (req, res, next) => {
   try {
     const result = await formService.getAllForms();
-
-    if (result.length > 0) {
-      res.status(HTTP_STATUS.OK).json(result);
-    } else {
-      const error = new Error('No form templates found');
-      error.statusCode = HTTP_STATUS.NOT_FOUND;
-      throw error;
-    }
+    res.status(HTTP_STATUS.OK).json(result);
   } catch (err) {
     next(err);
   }

--- a/app/src/controllers/formController.js
+++ b/app/src/controllers/formController.js
@@ -11,12 +11,25 @@ const createForm = async (req, res, next) => {
       message: 'Form template created successfully!',
     });
   } catch (err) {
+    // Log detailed error information for debugging
+    console.error('[createForm Error]', {
+      message: err.message,
+      statusCode: err.statusCode,
+      data: err.data,
+      stack: err.stack,
+      requestBody: {
+        hasFormversion: !!req.body?.formversion,
+        form_id: req.body?.formversion?.form_id || req.body?.form_id,
+        version: req.body?.formversion?.version || req.body?.version,
+        id: req.body?.formversion?.id || req.body?.id,
+      }
+    });
+
     if (!err.statusCode) {
       err.statusCode = HTTP_STATUS.INTERNAL_SERVER_ERROR;
-      err.message = 'Error creating form template';
     }
     if (err.statusCode === HTTP_STATUS.CONFLICT) {
-      err.details = { id: err.data?.id };
+      err.details = err.data;
     }
     next(err);
   }

--- a/app/src/controllers/pdfController.js
+++ b/app/src/controllers/pdfController.js
@@ -4,14 +4,7 @@ const { HTTP_STATUS } = require('../constants');
 const getAllPdfTemplates = async (req, res, next) => {
   try {
     const result = await pdfService.getAllPdfTemplates();
-
-    if (result.length > 0) {
-      res.status(HTTP_STATUS.OK).json(result);
-    } else {
-      const error = new Error('No pdf templates found');
-      error.statusCode = HTTP_STATUS.NOT_FOUND;
-      throw error;
-    }
+    res.status(HTTP_STATUS.OK).json(result);
   } catch (err) {
     next(err);
   }

--- a/app/src/services/formService.js
+++ b/app/src/services/formService.js
@@ -19,6 +19,8 @@ const normalizeFormData = (body) => {
       dataSources: fv.dataSources,
       data: fv.elements,
       interface: fv.interface,
+      scripts: fv.scripts,
+      styles: fv.styles,
     };
   } else {
     formData = {
@@ -32,6 +34,8 @@ const normalizeFormData = (body) => {
       dataSources: body.dataSources,
       data: body.data?.items || body.data,
       interface: body.interface,
+      scripts: body.scripts,
+      styles: body.styles,
     };
   }
 
@@ -65,6 +69,8 @@ const createForm = async (formData) => {
     dataSources: formData.dataSources ? JSON.stringify(formData.dataSources) : null,
     data: formData.data ? JSON.stringify(formData.data) : JSON.stringify([]),
     interface: formData.interface ? JSON.stringify(formData.interface) : JSON.stringify([]),
+    scripts: formData.scripts ? JSON.stringify(formData.scripts) : null,
+    styles: formData.styles ? JSON.stringify(formData.styles) : null,
   });
 
   return { id: formData.id };

--- a/app/src/services/formService.js
+++ b/app/src/services/formService.js
@@ -47,33 +47,69 @@ const normalizeFormData = (body) => {
 };
 
 const createForm = async (formData) => {
-  const existingForm = await db(TABLE_NAMES.FORM_TEMPLATES)
-    .where({ id: formData.id })
-    .first();
+  try {
+    const existingForm = await db(TABLE_NAMES.FORM_TEMPLATES)
+      .where({ id: formData.id })
+      .first();
 
-  if (existingForm) {
-    const error = new Error('Form template already exists');
-    error.statusCode = 409;
-    error.data = { id: formData.id };
+    if (existingForm) {
+      const error = new Error(`Form template already exists with id: ${formData.id}, form_id: ${existingForm.form_id}, version: ${existingForm.version}`);
+      error.statusCode = 409;
+      error.data = {
+        id: formData.id,
+        existing: {
+          form_id: existingForm.form_id,
+          version: existingForm.version,
+          title: existingForm.title
+        }
+      };
+      throw error;
+    }
+
+    await db(TABLE_NAMES.FORM_TEMPLATES).insert({
+      id: formData.id,
+      version: formData.version,
+      ministry_id: formData.ministry_id,
+      last_modified: formData.last_modified,
+      title: formData.title,
+      form_id: formData.form_id,
+      deployed_to: formData.deployed_to,
+      dataSources: formData.dataSources ? JSON.stringify(formData.dataSources) : null,
+      data: formData.data ? JSON.stringify(formData.data) : JSON.stringify([]),
+      interface: formData.interface ? JSON.stringify(formData.interface) : JSON.stringify([]),
+      scripts: formData.scripts ? JSON.stringify(formData.scripts) : null,
+      styles: formData.styles ? JSON.stringify(formData.styles) : null,
+    });
+
+    return { id: formData.id };
+  } catch (error) {
+    // Add context to database errors
+    if (!error.statusCode && error.code) {
+      console.error('[Database Error in createForm]', {
+        code: error.code,
+        detail: error.detail,
+        constraint: error.constraint,
+        formData: {
+          id: formData.id,
+          form_id: formData.form_id,
+          version: formData.version,
+          title: formData.title,
+        },
+      });
+
+      if (error.code === '23505') {
+        error.message = `Duplicate entry: ${error.detail || 'Form already exists'}`;
+        error.statusCode = 409;
+      } else if (error.code === '23502') {
+        error.message = `Missing required field: ${error.column || 'unknown'}`;
+        error.statusCode = 400;
+      } else {
+        error.message = `Database error: ${error.message}`;
+        error.statusCode = 500;
+      }
+    }
     throw error;
   }
-
-  await db(TABLE_NAMES.FORM_TEMPLATES).insert({
-    id: formData.id,
-    version: formData.version,
-    ministry_id: formData.ministry_id,
-    last_modified: formData.last_modified,
-    title: formData.title,
-    form_id: formData.form_id,
-    deployed_to: formData.deployed_to,
-    dataSources: formData.dataSources ? JSON.stringify(formData.dataSources) : null,
-    data: formData.data ? JSON.stringify(formData.data) : JSON.stringify([]),
-    interface: formData.interface ? JSON.stringify(formData.interface) : JSON.stringify([]),
-    scripts: formData.scripts ? JSON.stringify(formData.scripts) : null,
-    styles: formData.styles ? JSON.stringify(formData.styles) : null,
-  });
-
-  return { id: formData.id };
 };
 
 const getFormById = async (id) => {


### PR DESCRIPTION
## What changes did you make?

- Fixed `getAllForms` to return 200 with empty array instead of 404 when no forms exist
- Fixed `getAllPdfTemplates` to return 200 with empty array instead of 404 when no templates exist
- Added missing `aria-label` attributes
- Improved error messages and console.log more details about errors on upload process

## Why did you make these changes?

- Empty collections should return 200 OK with empty array `[]`, not 404 Not Found
- Fixed "Failed to fetch forms/templates" error messages when database is empty
- Browser console accessibility warnings resolved
- Get more details about errors happening in production

## What alternatives did you consider?

_Describe any alternative solutions you considered and why._

### Checklist

- [X] **I have assigned at least one reviewer**
- [X] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
