### PR TITLE
KILN V1 scripts and styles upload to template repo form

### DIFF
--- a/app/src/services/formService.js
+++ b/app/src/services/formService.js
@@ -34,8 +34,8 @@ const normalizeFormData = (body) => {
       dataSources: body.dataSources,
       data: body.data?.items || body.data,
       interface: body.interface,
-      scripts: body.scripts,
-      styles: body.styles,
+      scripts: body.data?.scripts || body.scripts,
+      styles: body.data?.styles || body.styles,
     };
   }
 


### PR DESCRIPTION
## What changes did you make?

Included the option to pull scripts and styles from JSON that has them listed under "data"

## Why did you make these changes?

Scripts and Styles were being added to the template repo with values "null" even when they were not. This meant they were not getting pulled from the correct location. Update has been made to include the original location but use body.data.styles if it exists.

For added info, this is what the console.log for "body" looked like:

<img width="214" height="112" alt="image" src="https://github.com/user-attachments/assets/93991305-6ba0-4f18-83f8-92fa430de1e7" />



### Checklist

- [X] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
