### PR TITLE
Update json import and copy/pull for kiln v1

### DIFF
--- a/app/src/services/formService.js
+++ b/app/src/services/formService.js
@@ -32,10 +32,12 @@ const normalizeFormData = (body) => {
       form_id: body.form_id,
       deployed_to: body.deployed_to || DEPLOYMENT_STATUS.NONE,
       dataSources: body.dataSources,
-      data: body.data?.items || body.data,
-      interface: body.interface,
-      scripts: body.data?.scripts || body.scripts,
-      styles: body.data?.styles || body.styles,
+      data: {
+        items: body.data?.items || body.data,
+        scripts: body.data?.scripts || body.scripts,
+        styles: body.data?.styles || body.styles
+      },
+      interface: body.interface
     };
   }
 


### PR DESCRIPTION
## What changes did you make?

Wrap items, scripts, and styles inside of "data" like the JSON export from Klamm has it

## Why did you make these changes?

Doing it this way means we don't have to update kiln v1 to reflect the JSON change.

KilnV2 form import still works and was not effected by this change.

## What alternatives did you consider?

Updating Kiln v1 to work with new JSON layout. That would have taken a lot longer to fix and likely would have had gaps. Doing it this way means keeping it the same as how Klamm exports (and likely how it was before the kiln v2 update).

### Checklist

- [X] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
