### PR TITLE
ADO-3477 elements and form_data columns

### DIFF
--- a/app/src/migrations/20251104182156_add_columns_to_form_templates.js
+++ b/app/src/migrations/20251104182156_add_columns_to_form_templates.js
@@ -1,0 +1,24 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  const exists = await knex.schema.hasTable("form_templates");
+  if (exists) {
+    return knex.schema.alterTable("form_templates", (table) => {
+      table.jsonb("elements");
+      table.jsonb("form_data");
+    });
+  }
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable("form_templates", (table) => {
+    table.dropColumn("elements");
+    table.dropColumn("form_data");
+  });
+};

--- a/app/src/services/formService.js
+++ b/app/src/services/formService.js
@@ -17,7 +17,9 @@ const normalizeFormData = (body) => {
       form_id: fv.form_id,
       deployed_to: fv.deployed_to || DEPLOYMENT_STATUS.NONE,
       dataSources: fv.dataSources,
-      data: fv.elements,
+      data: null,
+      form_data: fv.data,
+      elements: fv.elements,
       interface: fv.interface,
       scripts: fv.scripts,
       styles: fv.styles,
@@ -37,6 +39,8 @@ const normalizeFormData = (body) => {
         scripts: body.data?.scripts || body.scripts,
         styles: body.data?.styles || body.styles
       },
+      form_data: null,
+      elements: null,
       interface: body.interface
     };
   }
@@ -78,6 +82,8 @@ const createForm = async (formData) => {
       deployed_to: formData.deployed_to,
       dataSources: formData.dataSources ? JSON.stringify(formData.dataSources) : null,
       data: formData.data ? JSON.stringify(formData.data) : JSON.stringify([]),
+      elements: formData.elements ? JSON.stringify(formData.elements) : null,
+      form_data: formData.form_data ? JSON.stringify(formData.form_data) : null,
       interface: formData.interface ? JSON.stringify(formData.interface) : JSON.stringify([]),
       scripts: formData.scripts ? JSON.stringify(formData.scripts) : null,
       styles: formData.styles ? JSON.stringify(formData.styles) : null,


### PR DESCRIPTION
## What changes did you make?

Added "elements" and "form_data" columns to the form_templates database table. 

## Why did you make these changes?

Doing this allows the kiln-v2 forms to store their data in form tags that will then go on to be rendered accordingly (rather than before where kiln-v2 elements were being stored in "data" and not appearing as expected)

## What alternatives did you consider?

Re-writing kiln-v2, kiln-api, and comm layer in order to match the current state of the database. This would have taken much longer however and runs the risk of more errors.

The corresponding Comm Layer update for this change is in PR https://github.com/bcgov/Communication-Layer/pull/130

### Checklist

- [X] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
