### PR TITLE
ADO-3717 - Support saving barcode field on form templates

### DIFF
--- a/app/src/migrations/20260210103629_add_barcode_to_form_templates.js
+++ b/app/src/migrations/20260210103629_add_barcode_to_form_templates.js
@@ -1,0 +1,22 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  const exists = await knex.schema.hasTable("form_templates");
+  if (exists) {
+    return knex.schema.alterTable("form_templates", (table) => {
+      table.jsonb("barcode");
+    });
+  }
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable("form_templates", (table) => {
+    table.dropColumn("barcode");
+  });
+};

--- a/app/src/services/formService.js
+++ b/app/src/services/formService.js
@@ -23,6 +23,7 @@ const normalizeFormData = (body) => {
       interface: fv.interface,
       scripts: fv.scripts,
       styles: fv.styles,
+      barcode: fv.barcode || null,
     };
   } else {
     formData = {
@@ -41,7 +42,8 @@ const normalizeFormData = (body) => {
       },
       form_data: null,
       elements: null,
-      interface: body.interface
+      interface: body.interface,
+      barcode: body.barcode || null,
     };
   }
 
@@ -87,6 +89,7 @@ const createForm = async (formData) => {
       interface: formData.interface ? JSON.stringify(formData.interface) : JSON.stringify([]),
       scripts: formData.scripts ? JSON.stringify(formData.scripts) : null,
       styles: formData.styles ? JSON.stringify(formData.styles) : null,
+      barcode: formData.barcode ? JSON.stringify(formData.barcode) : null,
     });
 
     return { id: formData.id };


### PR DESCRIPTION
## What changes did you make?

Added a barcode JSONB column to the form_templates table and updated the form service to extract and save the barcode field when a form template is created.

## Why did you make these changes?

The barcode field was being dropped on save. Now it persists like the other form definition fields.

## What alternatives did you consider?

_Describe any alternative solutions you considered and why._

### Checklist

- [X] **I have assigned at least one reviewer**
- [X] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
